### PR TITLE
redisURL is now a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,23 @@ await server.register({
 
 // went smooth like chocolate :)
 ```
+You can also pass a connection string to ioReds. 
+
+```js
+await server.register({
+  plugin: require('hapi-rate-limitor'),
+  options: {
+    redis: 'redis://lolipop:SOME_PASSWORD@dokku-redis-lolipop:6379',
+    extensionPoint: 'onPreAuth',
+    namespace: 'hapi-rate-limitor'
+    // ... etc
+  }
+})
+
+// went smooth like chocolate :)
+```
+
+
 
 Please check the [async-ratelimiter API](https://github.com/microlinkhq/async-ratelimiter#api) for all options.
 

--- a/lib/rate-limiter.js
+++ b/lib/rate-limiter.js
@@ -41,8 +41,11 @@ class RateLimiter {
    * @returns {Redis}
    */
   createRedis (config) {
+    if (config.redisURL) {
+      return new Redis( config.redisURL, { lazyConnect: true } )
+    }
     return new Redis(
-      Object.assign(config, { lazyConnect: true })
+      Object.assign( config, { lazyConnect: true } )
     )
   }
 

--- a/lib/rate-limiter.js
+++ b/lib/rate-limiter.js
@@ -42,7 +42,9 @@ class RateLimiter {
    */
   createRedis (config) {
     if (config.redisURL) {
-      return new Redis( config.redisURL, { lazyConnect: true } )
+      const x = new Redis( config.redisURL, { lazyConnect: true } )
+      console.log(x)
+      return x;
     }
     return new Redis(
       Object.assign( config, { lazyConnect: true } )

--- a/lib/rate-limiter.js
+++ b/lib/rate-limiter.js
@@ -42,9 +42,7 @@ class RateLimiter {
    */
   createRedis (config) {
     if (config.redisURL) {
-      const x = new Redis( config.redisURL, { lazyConnect: true } )
-      console.log(x)
-      return x;
+      return new Redis( config.redisURL, { lazyConnect: true } )
     }
     return new Redis(
       Object.assign( config, { lazyConnect: true } )

--- a/lib/rate-limiter.js
+++ b/lib/rate-limiter.js
@@ -41,8 +41,8 @@ class RateLimiter {
    * @returns {Redis}
    */
   createRedis (config) {
-    if (config.redisURL) {
-      return new Redis(config.redisURL, { lazyConnect: true })
+    if (typeof config === 'string') {
+      return new Redis(config, { lazyConnect: true })
     }
     return new Redis(
       Object.assign(config, { lazyConnect: true })

--- a/lib/rate-limiter.js
+++ b/lib/rate-limiter.js
@@ -42,10 +42,10 @@ class RateLimiter {
    */
   createRedis (config) {
     if (config.redisURL) {
-      return new Redis(config.redisURL,{lazyConnect:true})
+      return new Redis(config.redisURL, { lazyConnect: true })
     }
     return new Redis(
-      Object.assign(config,{lazyConnect:true})
+      Object.assign(config, { lazyConnect: true })
     )
   }
 

--- a/lib/rate-limiter.js
+++ b/lib/rate-limiter.js
@@ -42,10 +42,10 @@ class RateLimiter {
    */
   createRedis (config) {
     if (config.redisURL) {
-      return new Redis( config.redisURL, { lazyConnect: true } )
+      return new Redis(config.redisURL,{lazyConnect:true})
     }
     return new Redis(
-      Object.assign( config, { lazyConnect: true } )
+      Object.assign(config,{lazyConnect:true})
     )
   }
 


### PR DESCRIPTION
Made it better by removing redisURL as a config option. It now checks to see if config is a string.
If config is a String, we can assume it to be a redis connection string. 

To me this felt more intuitive than using an object key.

Also, by passing it on an object, people might assume they can add additional config options to the object. However, these options would be ignored when a connection string is used. Using a string removes this confusion.

Also updated the Readme :)