### PR TITLE
fix(onPreResponse): Subsequent onPreResponse handlers are now evoked

### DIFF
--- a/lib/rate-limiter.js
+++ b/lib/rate-limiter.js
@@ -468,7 +468,7 @@ class RateLimiter extends RateLimitEventEmitter {
    */
   addHeaders (request, h) {
     return request.rateLimit
-      ? this.assignHeaders(request)
+      ? this.assignHeaders(request, h)
       : h.continue
   }
 
@@ -476,24 +476,25 @@ class RateLimiter extends RateLimitEventEmitter {
    * Assign rate limit response headers.
    *
    * @param {Request} request
+   * @param {ResponseTookit} h
    *
    * @returns {Response}
    */
-  assignHeaders ({ rateLimit, response }) {
+  assignHeaders ({ rateLimit, response }, h) {
     const { total, remaining, reset } = rateLimit
 
     if (response.isBoom) {
       response.output.headers['X-Rate-Limit-Limit'] = total
       response.output.headers['X-Rate-Limit-Remaining'] = Math.max(0, remaining)
       response.output.headers['X-Rate-Limit-Reset'] = reset
-
-      return response
-    }
-
-    return response
+    } else {
+      response
       .header('X-Rate-Limit-Limit', total)
       .header('X-Rate-Limit-Remaining', Math.max(0, remaining))
-      .header('X-Rate-Limit-Reset', reset)
+      .header('X-Rate-Limit-Reset', reset);
+    }
+
+    return h.continue;
   }
 }
 


### PR DESCRIPTION
Fixes http error response handling on OnPreResponse handler to allow subsequent onPreResponse handlers to be evoked with h.continue

Fix #238