### PR TITLE
Allow for passing of Redis client directly as options.redis

### DIFF
--- a/lib/rate-limiter.js
+++ b/lib/rate-limiter.js
@@ -35,7 +35,16 @@ class RateLimiter extends RateLimitEventEmitter {
     this.server = server
     this.duration = duration
     this.userAttribute = userAttribute
-    this.redis = this.createRedis(redis)
+
+    this.externalRedis = false;
+
+    if(redis instanceof Redis) {
+      this.externalRedis = true;
+      this.redis = redis;
+    } else {
+      this.redis = this.createRedis(redis)
+    }
+    
     this.ipWhitelist = [].concat(ipWhitelist)
     this.userLimitAttribute = userLimitAttribute
     this.limiter = this.createLimiter(rateLimiterOptions)
@@ -48,9 +57,7 @@ class RateLimiter extends RateLimitEventEmitter {
    *
    * @returns {Redis}
    */
-  createRedis (config) {
-    if(config instanceof Redis) return config;
-    
+  createRedis (config) {    
     if (typeof config === 'string') {
       return new Redis(config, { lazyConnect: true })
     }
@@ -101,14 +108,14 @@ class RateLimiter extends RateLimitEventEmitter {
    * Create a Redis connection.
    */
   async connectRedis () {
-    await this.redis.connect()
+    if(!this.externalRedis) await this.redis.connect()
   }
 
   /**
    * Close the Redis connection.
    */
   async disconnectRedis () {
-    await this.redis.quit()
+    if(!this.externalRedis) await this.redis.quit()
   }
 
   /**

--- a/lib/rate-limiter.js
+++ b/lib/rate-limiter.js
@@ -49,6 +49,8 @@ class RateLimiter extends RateLimitEventEmitter {
    * @returns {Redis}
    */
   createRedis (config) {
+    if(config instanceof Redis) return config;
+    
     if (typeof config === 'string') {
       return new Redis(config, { lazyConnect: true })
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hapi-rate-limitor",
   "description": "Rate limiting for hapi/hapi.js to prevent brute-force attacks",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "author": "Marcus Pöhls <marcus@futurestud.io>",
   "bugs": {
     "url": "https://github.com/futurestudio/hapi-rate-limitor/issues"


### PR DESCRIPTION
I needed more control over ioredis errors therefore needed to create my own `new Redis(config)` in my code and reuse it through HAPI. With these few lines it's possible to pass a full Redis client now instead of just a connections string or config object.